### PR TITLE
Fix template

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,8 @@ import { preprocessor, renderPlotly } from './preprocessor';
 const basicPlotlyChart = [
 	'```plotly',
 	'data:',
-	'\t- x: [0,1,2]',
-	'\t  y: [0,1,0]',
+	'- x: [0,1,2]',
+	'  y: [0,1,0]',
 	'```\n'
 ].join('\n')
 const NEW_PLOTLY_CHART_NAME = "New Plotly Chart";


### PR DESCRIPTION
Due to [this issue](https://github.com/Dmytro-Shulha/obsidian-plotly/issues/12) there is wrong template which can be inserted in obsidian by `ctrl+p` + `Plotly: New Plotly Chart`. Removing tabs fixes issue.